### PR TITLE
Add version to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "external-control",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "scripts": {
     "start": "cd external-control-frontend && npm run start",
     "install-frontend": "cd external-control-frontend && npm install",


### PR DESCRIPTION
I don't quite know where that pops up, but at least for building and installing the URCapX through npm, it was showing "external-control@0.0.0" otherwise.