### PR TITLE
Avoid 308 

### DIFF
--- a/external-control-backend/src/request_program.py
+++ b/external-control-backend/src/request_program.py
@@ -53,13 +53,18 @@ class RequestProgram(object):
             Exception: If the connection to the remote PC could not be established or no data is received.
         """
         program = ""
-        timeout = 5
+        connection_timeout = 5
+        receive_timeout = 1.0
         try:
             # Create a socket connection with the robot IP and port number defined above
             s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            s.settimeout(0.1)
-            s.connect((self.robotIP, self.port))
+            s.settimeout(connection_timeout)
+            try:
+                s.connect((self.robotIP, self.port))
+            except socket.timeout:
+                raise Exception(f"Connection timeout")
             s.sendall(command.encode('us-ascii'))
+            s.settimeout(receive_timeout)
             # Receive script code
             raw_data = b""
             begin = time.time()
@@ -73,9 +78,6 @@ class RequestProgram(object):
                     if raw_data != b"":
                         print("Done receiving data")
                         break
-                    elif time.time() - begin > timeout:
-                        s.close()
-                        raise Exception(f"Connection timeout")
             program = raw_data.decode("us-ascii")
             s.close()
             if not bool(program and program.strip()):

--- a/external-control-backend/src/request_program.py
+++ b/external-control-backend/src/request_program.py
@@ -55,6 +55,7 @@ class RequestProgram(object):
         program = ""
         connection_timeout = 5
         receive_timeout = 1.0
+        receive_timeout_overall = 5
         try:
             # Create a socket connection with the robot IP and port number defined above
             s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -78,6 +79,9 @@ class RequestProgram(object):
                     if raw_data != b"":
                         print("Done receiving data")
                         break
+                    elif time.time() - begin > receive_timeout_overall:
+                        s.close()
+                        raise socket.timeout(f"Timeout while receiving data")
             program = raw_data.decode("us-ascii")
             s.close()
             if not bool(program and program.strip()):

--- a/external-control-backend/src/simple_rest_api.py
+++ b/external-control-backend/src/simple_rest_api.py
@@ -68,7 +68,7 @@ def store_in_cache(cache_key, now, json_str, valid):
     if valid:
         program_cache[cache_key] = (now, json_str)
 
-@app.route('/<int:port>/<robotIP>/', methods=["GET"])
+@app.route('/<int:port>/<robotIP>/', methods=["GET"], strict_slashes=False )
 def read_params(port, robotIP):
     logger.info(f"Received request for port {port} and robot IP {robotIP}")
     cache_key = (port, robotIP)

--- a/external-control-backend/tests/test_request_program.py
+++ b/external-control-backend/tests/test_request_program.py
@@ -62,7 +62,7 @@ def test_send_command_timeout(monkeypatch):
     rp = RequestProgram(1234, '127.0.0.1')
     with pytest.raises(Exception) as exc:
         rp.send_command('request_program\n')
-    assert 'Connectivity problem with 127.0.0.1:1234: Connection timeout' in str(exc.value)
+    assert 'Connectivity problem with 127.0.0.1:1234: Timeout while receiving data' in str(exc.value)
     assert dummy.closed
 
 def test_send_command_connect_error(monkeypatch):


### PR DESCRIPTION
Fixes #26 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small HTTP routing and socket timeout behavior changes in the external-control backend; no auth or data-model impact.
> 
> **Overview**
> **Flask** GET route `/<port>/<robotIP>/` now sets **`strict_slashes=False`**, so requests with or without a trailing slash are handled directly instead of triggering a **308** redirect (fixes #26).
> 
> **`RequestProgram.send_command`** separates **connect** vs **receive** timeouts: **5s** for `connect`, **1s** per `recv` with a **5s** overall receive budget. Failed connects still surface **Connection timeout**; stalled receives with no data now raise **Timeout while receiving data**. The unit test expectation was updated for that message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 714c14682e468410b2722d21e3b62f559ef9092b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->